### PR TITLE
Same URL on all items breaks

### DIFF
--- a/rss-feed2@nixnodes.net/extension.js
+++ b/rss-feed2@nixnodes.net/extension.js
@@ -631,9 +631,9 @@ const RssFeed = new Lang.Class(
 		{
 			let item = rssParser.Items[i];
 			let itemURL = item.HttpLink;
-
-			if (itemCache[itemURL])
-				continue;
+			//If all feed items have the same url this bugs out.
+			//if (itemCache[itemURL])
+			//	continue;
 
 			/* remove HTML tags */
 			item.Title = Encoder.htmlDecode(item.Title).replace(/<.*?>/g, "").trim();


### PR DESCRIPTION
I've got this feed where a lot of the feed items are identical. And the URL is always the same. With this conditional, only one item shows up. Not sure what breaks when I comment this out, but it still seems fine.